### PR TITLE
feat: added DJAGGER_DOCUMENT url_names parameter to resolve url also with their names

### DIFF
--- a/djagger/openapi.py
+++ b/djagger/openapi.py
@@ -928,13 +928,14 @@ class Document(BaseModel):
         contact_url="",
         license_name="",
         license_url="",
+        url_names: List[str] = [],
         **kwargs,
     ) -> dict:
         """Inspects URLPatterns in given list of apps to generate the openAPI json object for the Django project.
         Returns the JSON string object for the resulting OAS document.
         """
 
-        url_patterns = get_url_patterns(app_names)
+        url_patterns = get_url_patterns(app_names, url_names)
         paths: Dict[str, Path] = {}
 
         for route, url_pattern in url_patterns:

--- a/djagger/utils.py
+++ b/djagger/utils.py
@@ -127,7 +127,8 @@ def list_urls(resolver: URLResolver, prefix="") -> List[Tuple[str, URLPattern]]:
     return results
 
 
-def get_url_patterns(app_names: List[str]) -> List[Tuple[str, URLPattern]]:
+
+def get_url_patterns(app_names: List[str], url_names: List[str] = []) -> List[Tuple[str, URLPattern]]:
     """Given a list of app names in the project, return a filtered list of URLPatterns that contains a view function or class
     that are part of the listed apps. Include all apps, less ``djagger`` if ``app_names`` is an empty list.
     """
@@ -150,6 +151,9 @@ def get_url_patterns(app_names: List[str]) -> List[Tuple[str, URLPattern]]:
         if app_names:
 
             if path_app_name not in app_names:
+                continue
+        elif url_names:
+            if url_pattern.name not in url_names:
                 continue
 
         results.append((path, url_pattern))

--- a/djagger/utils.py
+++ b/djagger/utils.py
@@ -152,7 +152,7 @@ def get_url_patterns(app_names: List[str], url_names: List[str] = []) -> List[Tu
 
             if path_app_name not in app_names:
                 continue
-        elif url_names:
+        if url_names:
             if url_pattern.name not in url_names:
                 continue
 


### PR DESCRIPTION
with this feature we extend the DJAGGER_DOCUMENT paramenters and we can configure the resouces also with url_names. Eg:

````
DJAGGER_DOCUMENT = {
    "app_names" : ['my_entire_app'],
    "url_names": ['oidc_provider_token_endpoint']
}
````