### PR TITLE
1.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,99 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.1] - 2021-04-06
+## [1.1.2] - 2022-04-06
+
+### Added
+- Added `url_names` parameter to `get_url_patterns` to allow `DJAGGER_DOCUMENT` to filter API endpoints that should be documented via their url names.
+- Added missing `.gitignore` file.
+
+### Fixed
+- Fixed date typos in this changelog file.
+
+## [1.1.1] - 2022-02-06
 ### Added
 - Rest framework ``serializers.ChoiceField`` and ``serializers.MultipleChoiceField`` will now be represented as ``Enum`` types with enum values correctly reflected in the schema.
 - Documentation for using Tags.
@@ -13,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug where schema examples are not generated correctly.
 - Fix bug where the request URL for the objects are generated with an incorrect prefix.
 
-## [1.1.0] - 2021-01-04
+## [1.1.0] - 2022-01-04
 ### Added
 - Added documentation.
 - Support for generic views and viewsets.

--- a/djagger/utils.py
+++ b/djagger/utils.py
@@ -127,10 +127,13 @@ def list_urls(resolver: URLResolver, prefix="") -> List[Tuple[str, URLPattern]]:
     return results
 
 
-
-def get_url_patterns(app_names: List[str], url_names: List[str] = []) -> List[Tuple[str, URLPattern]]:
+def get_url_patterns(
+    app_names: List[str], url_names: List[str] = []
+) -> List[Tuple[str, URLPattern]]:
     """Given a list of app names in the project, return a filtered list of URLPatterns that contains a view function or class
     that are part of the listed apps. Include all apps, less ``djagger`` if ``app_names`` is an empty list.
+
+    If ``url_names`` is provided, will further filter the list to only include URLPatterns that match the URL names as provided in the ``url_names`` list.
     """
     # List of app modules
     results = []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,12 +21,12 @@ settings.configure()
 
 # -- Project information -----------------------------------------------------
 
-project = "Djagger 1.1.1"
+project = "Djagger 1.1.2"
 copyright = "2022, royhzq"
 author = "royhzq"
 
 # The full version, including alpha/beta/rc tags
-release = "1.1.1"
+release = "1.1.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/release_history.rst
+++ b/docs/source/release_history.rst
@@ -1,6 +1,33 @@
 Release History
 ===============
 
+1.1.2
+-----
+
+**Added**
+
+* Added ``url_names`` parameter to ``get_url_patterns`` to allow ``DJAGGER_DOCUMENT`` to filter API endpoints that should be documented via their url names.
+* Added missing ``.gitignore`` file.
+
+**Fixed**
+
+* Fixed date typos in this changelog file.
+
+
+1.1.1
+-----
+
+**Added**
+
+* Rest framework ``serializers.ChoiceField`` and ``serializers.MultipleChoiceField`` will now be represented as ``Enum`` types with enum values correctly reflected in the schema.
+* Documentation for using Tags.
+
+**Fixed**
+
+* Fix bug where schema examples are not generated correctly.
+* Fix bug where the request URL for the objects are generated with an incorrect prefix.
+
+
 1.1.0
 -----
 


### PR DESCRIPTION
Prep for 1.1.2 release

### Added
- Added missing `.gitignore` file.

### Changed
- Updated changelog and sphinx docs.

### Fixed
- Fixed date typos in this changelog file.