### PR TITLE
Fixed duplicate content issue when we have more than 1 ListAPIView.

### DIFF
--- a/djagger/openapi.py
+++ b/djagger/openapi.py
@@ -821,8 +821,7 @@ class Path(BaseModel):
                     )  # i.e. get(), post(), put() ...
                     # Add the View class as an attribute 'cls' to the action view function
                     # as a fallback reference.
-                    if not hasattr(view_func, "cls"):
-                        view_func.cls = view
+                    view_func.cls = view
 
                     operation = Operation._from(view_func, http_method)
                     if not operation:

--- a/djagger/serializers.py
+++ b/djagger/serializers.py
@@ -95,7 +95,6 @@ class SerializerConverter(BaseModel):
         """
         mappings = {
             fields.BooleanField: bool,
-            fields.NullBooleanField: bool,
             fields.CharField: str,
             fields.EmailField: str,
             fields.RegexField: str,


### PR DESCRIPTION
To reproduce the issue, just create a project with two generic API views (inheriting from ListAPIView in my case) and do not override the get() method. Put custom description and response schema using the ``get_summary`` and ``response_schema`` shortcuts.
You end up with a documentation containing two routes (expected) but with the same content!

This is due to the fact that in the ``Document`` class, you end up playing with the ``get()`` method of the base class (``ListAPIView``), which remains the same instance whatever the route... With the ``if`` statement that was present, only the first view wins.

I guess this error might happen in other cases but I only tested the one described above.