### PR TITLE
Removed support for NullBooleanField

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2022-10-25
+
+### Removed
+
+- Removed support for DRF `NullBooleanField` field for compatibility with the latest DRF version 3.14.
+
 ## [1.1.3] - 2022-04-17
 
 ### Fixed

--- a/djagger/serializers.py
+++ b/djagger/serializers.py
@@ -95,7 +95,6 @@ class SerializerConverter(BaseModel):
         """
         mappings = {
             fields.BooleanField: bool,
-            fields.NullBooleanField: bool,
             fields.CharField: str,
             fields.EmailField: str,
             fields.RegexField: str,

--- a/djagger/utils.py
+++ b/djagger/utils.py
@@ -182,7 +182,6 @@ def infer_field_type(field: fields.Field):
     """
     mappings = {
         fields.BooleanField: bool,
-        fields.NullBooleanField: bool,
         fields.CharField: str,
         fields.EmailField: str,
         fields.RegexField: str,


### PR DESCRIPTION
## [1.1.4] - 2022-10-25

### Removed

- Removed support for DRF `NullBooleanField` field for compatibility with the latest DRF version 3.14.
